### PR TITLE
Add jitpack support

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk17

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,4 +7,4 @@
  * in the user manual at https://docs.gradle.org/5.6.3/userguide/multi_project_builds.html
  */
 
-rootProject.name = 'Lunar Core'
+rootProject.name = 'LunarCore'


### PR DESCRIPTION
Due to the following problems, we can't add LunarCore to our own plugin as a dependency via jitpack.
1. The gradle project name contains a space. ([build.log](https://jitpack.io/com/github/Melledy/LunarCore/v1.2.0/build.log))
2. Jitpack's default jdk 8 desn't work with LunarCore.

This PR will change the gradle project name to "LunarCore" (formerly "Lunar Core"), and create jitpack.yml to use jdk17 for jitpack build.