### PR TITLE
Change duplicate strategy to exclude

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -132,7 +132,7 @@ jar {
         configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
     }
 
-    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 
     from('src/main/java') {
         include '*.xml'


### PR DESCRIPTION
This pull request changes the duplicate strategy from include to exclude to prevent duplicate files.
This is mainly the case with my mod loader, but if the duplicate strategy is set to include, multiple files will be included in the same path in the jar file and will not be decompressed properly. It causes the transformer in gradle to not work and limits the development of the plugin.

[Here](https://github.com/yuko1101/LunarCoreRunner/blob/main/src/main/kotlin/io/github/yuko1101/lunarcorerunner/AccessWidenerTransformer.kt) is my transformer in gradle which does not work with LunarCore jar which built with duplicate strategy INCLUDE. It has the ability to change the access modifier from private or protected to public in an existing JAR file.