### PR TITLE
Fix application run task exits while running server

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,6 +114,11 @@ application {
     mainClassName = 'emu.lunarcore.LunarCore'
 }
 
+run {
+    // Set the standard input to wait for user input
+    standardInput = System.in
+}
+
 jar {
 	dependsOn 'injectGitHash'
 


### PR DESCRIPTION
Hi, I found the application run task exists right after initializing the server. (Please close this PR if it's intended.)
This PR sets the standardInput for `run` task, and make the task wait for user input.