### PR TITLE
Don't load all classes in the plugin JAR on load

### DIFF
--- a/src/main/java/emu/lunarcore/plugin/PluginManager.java
+++ b/src/main/java/emu/lunarcore/plugin/PluginManager.java
@@ -108,18 +108,6 @@ public final class PluginManager {
                     return;
                 }
 
-                // Load all classes in the plugin's JAR file.
-                var pluginJar = new JarFile(pluginFile);
-                var entries = pluginJar.entries();
-                while (entries.hasMoreElements()) {
-                    var entry = entries.nextElement();
-                    if (entry.isDirectory() || !entry.getName().endsWith(".class")) continue;
-
-                    var className = entry.getName().substring(0, entry.getName().length() - 6);
-                    className = className.replace('/', '.');
-                    classLoader.loadClass(className);
-                }
-
                 // Instantiate the plugin.
                 var pluginClass = classLoader.loadClass(pluginConfig.mainClass());
                 var pluginInstance = (Plugin) pluginClass.getDeclaredConstructor(


### PR DESCRIPTION
Loading a plugin with an unused invalid class cause an error (even though the class is unused) because the PluginManager forcefully loads all classes in plugin JARs on load.

The problem would be a problem when you make a plugin which soft depends* on another plugin, or a plugin which can be also loaded by another mod loader. 
*A soft dependency is a dependency which is desirable but not essential for the program (The phrase "soft depend" is taken from Minecraft Spigot).

Though I tested some plugins with this change and all of them worked properly, please let me know if this can break some plugins.